### PR TITLE
Fix sublate build path

### DIFF
--- a/colors/spectrum.yaml
+++ b/colors/spectrum.yaml
@@ -10,14 +10,14 @@ spectrum:
     blue: 5ad4e6
     purple: 948ae3
     # base colors
-    base0: 131313
-    base1: 191919
-    base2: 222222
-    base3: 363537
+    base0: 161616
+    base1: 161616
+    base2: 161616
+    base3: 222222
     base4: 525053
     base5: 69676c
     base6: 8b888f
     base7: bab6c0
     base8: f7f1ff
     # variants
-    base8x0c: 2b2b2b
+    base8x0c: 161616

--- a/sublate.yaml
+++ b/sublate.yaml
@@ -1,2 +1,2 @@
 data: colors
-main: theme
+path: theme

--- a/theme/jetbrains/templates/scheme.xml
+++ b/theme/jetbrains/templates/scheme.xml
@@ -78,7 +78,7 @@
     <option name="ScrollBar.trackColor" value="{{theme.colors.base2}}" />
     <option name="TAB_UNDERLINE" value="{{theme.colors.yellow}}" />
     <option name="TAB_UNDERLINE_INACTIVE" value="{{theme.colors.yellow}}" />
-    <option name="TEARLINE_COLOR" value="{{theme.colors.base8x0c}}" />
+    <option name="TEARLINE_COLOR" value="{{theme.colors.base3}}" />
     <option name="TOOLTIP" value="{{theme.colors.base3}}" />
     <option name="VCS_ANNOTATIONS_COLOR_1" value="{{theme.colors.base5}}" />
     <option name="VCS_ANNOTATIONS_COLOR_2" value="59575a" />


### PR DESCRIPTION
This attribute was changed from 'path' to 'main' in a previous commit result in the `sublate` command to fail as it ended up recursively creating 'output' folders. 

This commit reverts the attribute to be 'path' which fixes this issue. 